### PR TITLE
Add helpers and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "midi20"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midi20"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   "Mike Hilgendorf <mike@hilgendorf.audio>",
   "Lukas Navickas <lukas.navickas@icloud.com>"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright © 2021 Michael Hilgendorf
+Copyright © 2024 Michael Hilgendorf
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -35,9 +35,7 @@ pub fn decode(buf: &[u8]) -> Option<(usize, Data)> {
             let packet = Packet::<2>([word0, word1]);
             let data = match message_type {
                 0x3 => Data::Data64(data::Data64::from_packet_unchecked(packet)),
-                0x4 => Data::ChannelVoice(
-                    channel2::ChannelVoice::from_packet_unchecked(packet),
-                ),
+                0x4 => Data::ChannelVoice(channel2::ChannelVoice::from_packet_unchecked(packet)),
                 _ => Data::Reserved64(packet),
             };
             Some((8, data))
@@ -56,9 +54,7 @@ pub fn decode(buf: &[u8]) -> Option<(usize, Data)> {
             let data = match message_type {
                 0x5 => Data::Data128(data::Data128::from_packet_unchecked(packet)),
                 0xd => Data::Flex(flex::Flex::from_packet_unchecked(packet)),
-                0xf => {
-                    Data::UmpStream(ump_stream::UmpStream::from_packet_unchecked(packet))
-                }
+                0xf => Data::UmpStream(ump_stream::UmpStream::from_packet_unchecked(packet)),
                 _ => Data::Reserved128(packet),
             };
             Some((16, data))

--- a/src/message.rs
+++ b/src/message.rs
@@ -39,7 +39,7 @@ where
 
 /// Parent type of each MIDI Message.
 #[derive(Copy, Clone, Hash, Debug, Eq, PartialEq)]
-pub enum MidiMessageData {
+pub enum Data {
     /// Utility types (Jitter reduction, Clock, No-op).
     Utility(utility::Utility),
 
@@ -75,4 +75,24 @@ pub enum MidiMessageData {
 
     /// Reserved.
     Reserved128(Packet128),
+}
+
+impl Data {
+    /// The size of this message's packet in bytes.
+    pub fn packet_size(&self) -> usize {
+        match self {
+            Self::Utility(d) => std::mem::size_of_val(d),
+            Self::System(d) => std::mem::size_of_val(d),
+            Self::LegacyChannelVoice(d) => std::mem::size_of_val(d),
+            Self::ChannelVoice(d) => std::mem::size_of_val(d),
+            Self::Flex(d) => std::mem::size_of_val(d),
+            Self::UmpStream(d) => std::mem::size_of_val(d),
+            Self::Data64(d) => std::mem::size_of_val(d),
+            Self::Data128(d) => std::mem::size_of_val(d),
+            Self::Reserved32(d) => std::mem::size_of_val(d),
+            Self::Reserved64(d) => std::mem::size_of_val(d),
+            Self::Reserved96(d) => std::mem::size_of_val(d),
+            Self::Reserved128(d) => std::mem::size_of_val(d),
+        }
+    }
 }

--- a/src/message/flex.rs
+++ b/src/message/flex.rs
@@ -165,7 +165,6 @@ impl From<FlexStatus> for u16 {
     }
 }
 
-///
 #[derive(Copy, Clone, Hash, Debug, Eq, PartialEq)]
 pub enum FlexSetupAndPerformance {
     SetTempo,

--- a/src/message/ump_stream.rs
+++ b/src/message/ump_stream.rs
@@ -197,9 +197,9 @@ pub struct DeviceIdentityNotification {
     pub version_id: u8,
 }
 
-pub struct EndpointNameIdentification([u8; 14]);
+pub struct EndpointNameIdentification(pub [u8; 14]);
 
-pub struct ProductInstanceIdNotification([u8; 14]);
+pub struct ProductInstanceIdNotification(pub [u8; 14]);
 
 pub struct StreamConfigurationRequest {
     pub protocol: u8,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,5 +1,5 @@
 //! Implements serializing and deserializing MIDI messages as universal midi packets (UMP)
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 
 /// A universal midi packet (UMP) is a 32, 64, 96, or 128 bit slice of serialized
 /// MIDI data that is parsed into midi messages, or serialized from them.
@@ -11,6 +11,12 @@ impl<const N: usize> Deref for Packet<N> {
     type Target = [u32];
     fn deref(&self) -> &'_ Self::Target {
         &self.0
+    }
+}
+
+impl<const N: usize> DerefMut for Packet<N> {
+    fn deref_mut(&mut self) -> &'_ mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
- Rename `MidiMesageData` to `Data`
- Add `packet_size` method to `Data` to get the size of the underlying packet in bytes.
- Add helpers to construct channel voice messages.
- Various cleanup..